### PR TITLE
Fix doc typo

### DIFF
--- a/src/components/common/DiceRoller.tsx
+++ b/src/components/common/DiceRoller.tsx
@@ -6,7 +6,7 @@ import { useCallback, useState } from 'react';
  * @property {number} hot - Character's Hot stat
  * @property {number} cold - Character's Cold stat
  * @property {number} dark - Character's Dark stat
- * @property {number} volatile - Caracter's Volatile stat
+ * @property {number} volatile - Character's Volatile stat
  */
 interface Stats {
     hot: number;


### PR DESCRIPTION
## Summary
- fix typo in DiceRoller Stats interface JSDoc

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6840767730e88327ac5eb0992e930e87